### PR TITLE
Update base.html

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -84,7 +84,7 @@ h1:hover > .headerlink, h2:hover > .headerlink, h3:hover > .headerlink, h4:hover
 	    <li><a href="/test/">Test</a></li>
 	    <li><a href="/test/flood/">Flood</a></li>
 	    <li><a href="/apreq/">libapreq</a></li>
-	    <li><a href="/modules">Modules</a></li>
+	    <li><a href="/docs/2.4/mod/">Modules</a></li>
 	    <li><a href="/mod_fcgid/">mod_fcgid</a></li>
 	    <li><a href="/mod_ftp/">mod_ftp</a></li>
 	  </ul>


### PR DESCRIPTION
Refer to actual Module Index instead of outdated /modules page. Also mentioned https://modules.apache.org in /modules page does not exist.