### PR TITLE
Update base.html

### DIFF
--- a/theme/apache/templates/base.html
+++ b/theme/apache/templates/base.html
@@ -112,7 +112,7 @@ h1:hover > .headerlink, h2:hover > .headerlink, h3:hover > .headerlink, h4:hover
             <!-- FOOTER -->
             <div id="footer">
 	      <p>Copyright &copy; 1997-{{ CURRENTYEAR }} The Apache Software Foundation.<br />
-		Apache HTTP Server, Apache, and the Apache feather logo are trademarks of The Apache Software Foundation.</p>
+		Apache HTTP Server, Apache, and the Apache logo are trademarks of The Apache Software Foundation.</p>
             </div>
         </div>
     </body>


### PR DESCRIPTION
Remove "feather" from the attribution text in the page footer to adhere to the updated Trademark Attribution Policy: https://apache.org/foundation/marks/pmcs.html#attributions

For discussion: The attribution policy also lists "the Apache Foo project logo". Should this be added as well?