### PR TITLE
Remove dead links and modernize mailing list references

### DIFF
--- a/content/ABOUT_APACHE.md
+++ b/content/ABOUT_APACHE.md
@@ -94,10 +94,7 @@ https://httpd.apache.org/dev/ &gt;.
 > for people actively working on development of the server code. There is
 > also a 'docs' subproject for those who are actively developing and
 > translating the documentation. If you have user/configuration questions,
-> subscribe to the [Users list](../userslist.html) or try the USENET
-> newsgroups " <news:comp.infosystems.www.servers.unix> " or "
-> <news:comp.infosystems.www.servers.ms-windows> " (as appropriate for
-> the platform you use).
+> subscribe to the [Users list](../userslist.html).
 
 # Development  {#Development}
 
@@ -169,7 +166,7 @@ individuals, is a tremendously good thing.
 Furthermore, the Apache Software Foundation is an organic entity; those who
 benefit from this software by using it, often contribute back to it by
 providing feature enhancements, bug fixes, and support for others in public
-lists and newsgroups. The effort expended by any particular individual is
+lists. The effort expended by any particular individual is
 usually fairly light, but the resulting product is made very strong. These
 kinds of communities can only happen with freely available software -- when
 someone has paid for software, they usually aren't willing to fix its bugs

--- a/content/apreq/index.md
+++ b/content/apreq/index.md
@@ -62,7 +62,7 @@ You can download the latest version of *libapreq* from:
 
 -  [ASF mirror](/apreq/download.cgi) 
 
--  [CPAN](http://search.cpan.org/search?mode=module&amp;query=libapreq)
+-  [CPAN](https://metacpan.org/search?q=libapreq)
 ('perl -MCPAN -e "install libapreq"')
 
 # Mailing Lists #
@@ -72,16 +72,8 @@ There are two mailing lists devoted to the development of *libapreq*.
 [apreq-dev@httpd.apache.org](mailto:apreq-dev-subscribe@httpd.apache.org) -
 discusses libapreq development
 
--  [list
-archives](http://marc.theaimsgroup.com/?l=apreq-dev&amp;r=1&amp;w=2) 
-
--  [NNTP gateway](nntp://news.gmane.org/gmane.comp.apache.apreq) 
-
 [apreq-cvs@httpd.apache.org](mailto:apreq-cvs-subscribe@httpd.apache.org) -
 cvs commit logs for httpd-apreq and httpd-apreq-2
-
--  [list
-archives](http://marc.theaimsgroup.com/?l=apreq-cvs&amp;r=1&amp;w=2) 
 
 # SVN #
 

--- a/content/docs-project/contribute.md
+++ b/content/docs-project/contribute.md
@@ -67,7 +67,7 @@ Some of the participants are:
 
 -  [Ken Coar](http://Golux.Com/coar/) 
 
--  [Eric Cholet](http://www.logilune.com/eric/) 
+-  Eric Cholet
 
 -  [Tony Finch](http://dotat.at/) 
 

--- a/content/docs-project/translations.md
+++ b/content/docs-project/translations.md
@@ -7,7 +7,7 @@ We encourage translations of the documentation into other languages and thank
 you in advance for your contribution. If you would like to assist in translating
 the docs, please start by reading the general [documentation project
 information](./) , and subscribing to the [documentation project mailing
-list](http://mail-archives.apache.org/mod_mbox/httpd-docs/). The documentation
+list](https://lists.apache.org/list.html?docs@httpd.apache.org). The documentation
 project participants are usually very willing to help you with any questions or
 technical difficulties that may arise during your work.
 

--- a/content/lists.md
+++ b/content/lists.md
@@ -8,15 +8,8 @@ should consider subscribing to the [Announcements](#http-announce) or [User
 Support](#http-users) mailing lists. Other lists are for people interested
 in helping with the development and debugging of the server.
 
-Formatted archives are available in several places including [the Apache
-Mail Archives](http://mail-archives.apache.org/mod_mbox/) ,
-[MarkMail](http://httpd.markmail.org/) , and
-[MARC](http://marc.info/). Raw mbox archives for most lists are
-available at
-[https://httpd.apache.org/mail/](https://httpd.apache.org/mail/). You can
-also use the mail-to-news [gateway](nntp://news.gmane.org/) offered by
-[GMANE](http://news.gmane.org/index.php?match=gmane.comp.apache) to access
-most of the lists with a news reader.
+List archives are available in [the Apache
+Mail Archives](https://lists.apache.org/list.html?dev@httpd.apache.org).
 
 -  [Apache Server Announcements](#http-announce) 
 
@@ -30,18 +23,13 @@ most of the lists with a news reader.
 
 -  [Apache HTTP Server Documentation Project](#http-docs) 
 
--  [Third-Party Module Authors' List](#modules-dev) 
-
--  [Proxy Module Rework Discussion List](#http-proxydev) 
-
 # Apache Server Announcements  {#http-announce}
 
 The `announce@httpd.apache.org` mailing list is used to announce major
 releases and other important information about the Apache HTTP Server
-project. Messages are posted only by the Foundation; there is no
+project. Messages are posted only by the project; there is no
 discussion.
 
-| Volume: | Very low ([Statistics](https://lists.apache.org/trends.html?announce@httpd.apache.org)) |
 |---|---|
 | Subscription address: |  [announce-subscribe@httpd.apache.org](mailto:announce-subscribe@httpd.apache.org)  |
 | Unsubscription address: |  [announce-unsubscribe@httpd.apache.org](mailto:announce-unsubscribe@httpd.apache.org)  |
@@ -63,37 +51,8 @@ their advice, you will discover that these forums have dozens of helpers
 ready to provide you with guidance on using the Apache HTTP Server! **Note:
 Do not send your Apache questions to Eric or Rick!** 
 
-There are now a few **Apache HTTP Server Users Mailing Lists** available in
-different languages.
-
-They are described on separate pages:
-
--  [English list](userslist.html) 
-
--  [German list](usersdelist.html) 
-
-In addition, there are a few usenet discussion groups in which discussions
-about the server can be found. These include:
-
-- comp.infosystems.www.servers.unix [
-[nntp](nntp://comp.infosystems.www.servers.unix) ] [
-[google](https://groups.google.com/forum/#!forum/comp.infosystems.www.servers.unix)
-]
-
-- comp.infosystems.www.servers.ms-windows [
-[nntp](nntp://comp.infosystems.www.servers.ms-windows) ] [
-[google](https://groups.google.com/forum/#!forum/comp.infosystems.www.servers.ms-windows)
-]
-
-- comp.infosystems.www.authoring.cgi [
-[nntp](nntp://comp.infosystems.www.authoring.cgi) ] [
-[google](https://groups.google.com/forum/#!forum/comp.infosystems.www.authoring.cgi)
-]
-
-- de.comm.software.webserver<small>( *german* )</small>[
-[nntp](nntp://de.comm.software.webserver) ] [
-[google](https://groups.google.com/forum/#!forum/de.comm.software.webserver)
-]
+The **Apache HTTP Server Users Mailing List** is described on a
+[separate page](userslist.html).
 
 # Apache HTTP Server Development Main Discussion List  {#http-dev}
 
@@ -109,14 +68,12 @@ Configuration and support questions should be addressed to a [user support
 group](#http-users). This list is only for discussion of changes to the
 source code and related issues. Other questions are likely to be ignored.
 
-| Volume: | Low ([Statistics](https://lists.apache.org/trends.html?dev@httpd.apache.org)) |
 |---|---|
 | Subscription address: |  [dev-subscribe@httpd.apache.org](mailto:dev-subscribe@httpd.apache.org) ( **Not a user support list!** ) |
 | Digest subscription address: |  [dev-digest-subscribe@httpd.apache.org](mailto:dev-digest-subscribe@httpd.apache.org)  |
 | Unsubscription address: |  [dev-unsubscribe@httpd.apache.org](mailto:dev-unsubscribe@httpd.apache.org)  |
 | Getting help with the list: |  [dev-help@httpd.apache.org](mailto:dev-help@httpd.apache.org) , [dev-digest-help@httpd.apache.org](mailto:dev-digest-help@httpd.apache.org)  |
-| Searchable Archives: | [ASF browseable](https://lists.apache.org/list.html?dev@httpd.apache.org), [MARC archives](http://marc.info/?l=apache-new-httpd), [Mail-Archive.Com](http://www.mail-archive.com/dev%40httpd.apache.org/) 
-| Mail-To-News gateway: |  [gmane.comp.apache.devel](nntp://news.gmane.org/gmane.comp.apache.devel)  |
+| Searchable Archives: | [ASF browseable](https://lists.apache.org/list.html?dev@httpd.apache.org), [Mail-Archive.Com](http://www.mail-archive.com/dev%40httpd.apache.org/) |
 
 # Apache HTTP Server Bug Reports List  {#http-bugdb}
 
@@ -129,13 +86,11 @@ If you take ownership of bug by assigning it to yourself, please remember
 to add this mailing list to the cc: list so that the list continues to
 receive updates.
 
-| Volume: | Medium ([Statistics](https://lists.apache.org/trends.html?bugs@httpd.apache.org))|
 |---|---|
 | Subscription address: |  [bugs-subscribe@httpd.apache.org](mailto:bugs-subscribe@httpd.apache.org)  |
 | Unsubscription addresses: |  [bugs-unsubscribe@httpd.apache.org](mailto:bugs-unsubscribe@httpd.apache.org)  |
 | Getting help with the list: |  [bugs-help@httpd.apache.org](mailto:bugs-help@httpd.apache.org)  |
-| Searchable Archives: | [ASF Archives](https://lists.apache.org/list.html?bugs@httpd.apache.org), [MARC Archives](http://marc.info/?l=apache-httpd-bugs) | 
-| Mail-To-News gateway: |  [gmane.comp.apache.bugs](nntp://news.gmane.org/gmane.comp.apache.bugs)  |
+| Searchable Archives: | [ASF Archives](https://lists.apache.org/list.html?bugs@httpd.apache.org) |
 
 # Source Change Reports  {#http-cvs}
 
@@ -144,50 +99,22 @@ of changes applied to the master Subversion repository. As changes are
 applied, Subversion log messages are sent to all subscribers. (The list
 name is an artifact of the fact that we used to use CVS.)
 
-| Volume: | Low to moderate ([Statistics](https://lists.apache.org/trends.html?cvs@httpd.apache.org)) |
 |---|---|
 | Subscription address: |  [cvs-subscribe@httpd.apache.org](mailto:cvs-subscribe@httpd.apache.org)  |
 | Unsubscription addresses: |  [cvs-unsubscribe@httpd.apache.org](mailto:cvs-unsubscribe@httpd.apache.org)  |
 | Getting help with the list: |  [cvs-help@httpd.apache.org](mailto:cvs-help@httpd.apache.org)  |
-| Searchable Archives: | [ASF Archives](https://lists.apache.org/list.html?cvs@httpd.apache.org), [MARC Archives](http://marc.info/?l=apache-cvs)| 
-| Mail-To-News gateway: |  [gmane.comp.apache.cvs](nntp://news.gmane.org/gmane.comp.apache.cvs)  |
+| Searchable Archives: | [ASF Archives](https://lists.apache.org/list.html?cvs@httpd.apache.org) |
 
 # Apache HTTP Server Documentation Project  {#http-docs}
 
-This mailing list is used by the people working on improving and
-translating the documentation of the Apache HTTP server. It is primarily
-used for discussion of changes to the documentation.
+This mailing list supports the
+[Apache HTTP Server Documentation Project](https://httpd.apache.org/docs-project/),
+which coordinates improvements and translations of the server documentation.
+Subscribe here to discuss documentation changes and contribute.
 
-| Volume: | Low to moderate ([Statistics](https://lists.apache.org/trends.html?docs@httpd.apache.org)) |
 |---|---|
 | Subscription address: |  [docs-subscribe@httpd.apache.org](mailto:docs-subscribe@httpd.apache.org)  |
 | Unsubscription addresses: |  [docs-unsubscribe@httpd.apache.org](mailto:docs-unsubscribe@httpd.apache.org)  |
 | Getting help with the list: |  [docs-help@httpd.apache.org](mailto:docs-help@httpd.apache.org)  |
-| Searchable Archives: | [ASF Archives](https://lists.apache.org/list.html?docs@httpd.apache.org), [MARC Archives](http://marc.info/?l=apache-docs)| 
-| Mail-To-News gateway: |  [gmane.comp.apache.documentation](nntp://news.gmane.org/gmane.comp.apache.documentation)  |
+| Searchable Archives: | [ASF Archives](https://lists.apache.org/list.html?docs@httpd.apache.org) |
 
-# Third-Party Module Authors' List  {#modules-dev}
-
-This mailing list is for people who are actually involved in writing
-third-party or private modules for the Apache HTTP server. It is a peer
-support list for programmers to discuss issues surrounding the development
-of web server modules using the Apache HTTP Server module and APR APIs. It
-was historically hosted at apache-modules@covalent.net, now closed, but
-still archived on MARC (see Archives, below).
-
-| Volume: | Low |
-|---|---|
-| Subscription address: |  [modules-dev-subscribe@httpd.apache.org](mailto:modules-dev-subscribe@httpd.apache.org)  |
-| Unsubscription addresses: |  [modules-dev-unsubscribe@httpd.apache.org](mailto:modules-dev-unsubscribe@httpd.apache.org)  |
-| Getting help with the list: |  [modules-dev-help@httpd.apache.org](mailto:modules-dev-help@httpd.apache.org)  |
-| Searchable Archive: |  [Browse httpd-modules-dev](https://lists.apache.org/list.html?modules-dev@httpd.apache.org)  |
-
-# Proxy Module Rework Discussion List  {#http-proxydev}
-
-This list is closed. Proxy development discussion should take place on the
-main dev list. Archives are still available for research. Direct all
-development questions to the [Main Development Discussion List](#http-dev).
-
-Archives: 
-
-* Searchable: [MARC Archives](http://marc.info/?l=apache-modproxy-dev)

--- a/content/mod_ftp/index.md
+++ b/content/mod_ftp/index.md
@@ -37,11 +37,11 @@ list.
 
 -  [dev@httpd.apache.org](mailto:dev-subscribe@httpd.apache.org) -
 development (
-[archives](http://mail-archives.apache.org/mod_mbox/httpd-dev/) ).
+[archives](https://lists.apache.org/list.html?dev@httpd.apache.org) ).
 
 -  [cvs@httpd.apache.org](mailto:cvs-subscribe@httpd.apache.org) - svn
 commit logs for httpd, including mod_ftp (
-[archives](http://mail-archives.apache.org/mod_mbox/httpd-cvs/) ).
+[archives](https://lists.apache.org/list.html?cvs@httpd.apache.org) ).
 
 # History #
 

--- a/content/mod_mbox/index.md
+++ b/content/mod_mbox/index.md
@@ -32,11 +32,11 @@ list.
 
 -  [dev@httpd.apache.org](mailto:dev-subscribe@httpd.apache.org) - module
 development (
-[archives](http://mail-archives.apache.org/mod_mbox/httpd-dev/) ).
+[archives](https://lists.apache.org/list.html?dev@httpd.apache.org) ).
 
 -  [cvs@httpd.apache.org](mailto:cvs-subscribe@httpd.apache.org) - svn
 commit logs for httpd, including mod_mbox (
-[archives](http://mail-archives.apache.org/mod_mbox/httpd-cvs/) ).
+[archives](https://lists.apache.org/list.html?cvs@httpd.apache.org) ).
 
 # Subversion repository #
 

--- a/content/mod_smtpd/index.md
+++ b/content/mod_smtpd/index.md
@@ -47,11 +47,11 @@ list.
 
 -  [dev@httpd.apache.org](mailto:dev-subscribe@httpd.apache.org) - module
 development (
-[archives](http://mail-archives.apache.org/mod_mbox/httpd-dev/) ).
+[archives](https://lists.apache.org/list.html?dev@httpd.apache.org) ).
 
 -  [cvs@httpd.apache.org](mailto:cvs-subscribe@httpd.apache.org) - svn
 commit logs for httpd, including mod_mbox (
-[archives](http://mail-archives.apache.org/mod_mbox/httpd-cvs/) ).
+[archives](https://lists.apache.org/list.html?cvs@httpd.apache.org) ).
 
 # History #
 

--- a/content/support.md
+++ b/content/support.md
@@ -10,12 +10,12 @@ presented here in the order in which you should probably consult them.
 source for information about the Apache httpd. The answers to your questions
 are probably there.
 
-The [Apache HTTP Server Users List](/lists.html#http-users) , or the Usenet
-groups listed on that same page, are great places to ask questions when you
-are willing to wait a few hours, or possibly a few days, for an answer.
+The [Apache HTTP Server Users List](/lists.html#http-users) is a great
+place to ask questions when you are willing to wait a few hours, or
+possibly a few days, for an answer.
 These lists are frequented by people intimately familiar with the Apache
 httpd, who are willing to address your questions. You are strongly
-encouraged to consult the [archives](http://httpd.markmail.org/) prior to
+encouraged to consult the [archives](https://lists.apache.org/list.html?users@httpd.apache.org) prior to
 asking a question.
 
 The `#httpd` channel on the

--- a/content/test/flood/index.md
+++ b/content/test/flood/index.md
@@ -65,26 +65,18 @@ notifications
 
 Archives
 
--  [dev Archives](http://mail-archives.apache.org/mod_mbox/httpd-dev/) 
+-  [dev Archives](https://lists.apache.org/list.html?dev@httpd.apache.org) 
 
--  [cvs Archives](http://mail-archives.apache.org/mod_mbox/httpd-cvs/) 
-
--  [dev Archives (Raw)](https://httpd.apache.org/mail/dev/) 
-
--  [cvs Archives (Raw)](https://httpd.apache.org/mail/cvs/) 
+-  [cvs Archives](https://lists.apache.org/list.html?cvs@httpd.apache.org) 
 
 On December 22, 2005, test-dev@httpd.apache.org was merged with
 dev@httpd.apache.org. Our old archives are still available.
 
 -  [test-dev
-Archives](http://mail-archives.apache.org/mod_mbox/httpd-test-dev/) 
+Archives](https://lists.apache.org/list.html?test-dev@httpd.apache.org) 
 
 -  [test-cvs
-Archives](http://mail-archives.apache.org/mod_mbox/httpd-test-cvs) 
-
--  [test-dev Archives (Raw)](https://httpd.apache.org/mail/test-dev/) 
-
--  [test-cvs Archives (Raw)](https://httpd.apache.org/mail/test-cvs/) 
+Archives](https://lists.apache.org/list.html?test-cvs@httpd.apache.org) 
 
 # License  {#License}
 

--- a/content/test/index.md
+++ b/content/test/index.md
@@ -33,27 +33,19 @@ commit notifications
 Archives
 
 -  [dev@httpd
-Archives](http://mail-archives.apache.org/mod_mbox/httpd-dev/) 
+Archives](https://lists.apache.org/list.html?dev@httpd.apache.org)
 
 -  [cvs@httpd
-Archives](http://mail-archives.apache.org/mod_mbox/httpd-cvs/) 
-
--  [dev@httpd Archives (Raw)](https://httpd.apache.org/mail/dev/) 
+Archives](https://lists.apache.org/list.html?cvs@httpd.apache.org)
 
 On December 22, 2005, test-dev@httpd.apache.org was merged with
 dev@httpd.apache.org. Our old archives are still available.
 
 -  [Test-dev
-Archives](http://mail-archives.apache.org/mod_mbox/httpd-test-dev/) 
+Archives](https://lists.apache.org/list.html?test-dev@httpd.apache.org)
 
 -  [Test-cvs
-Archives](http://mail-archives.apache.org/mod_mbox/httpd-test-cvs/) 
-
--  [Test-dev Archives](http://marc.theaimsgroup.com/?l=apache-test-dev) 
-
--  [Test-dev Archives (Raw)](https://httpd.apache.org/mail/test-dev/) 
-
--  [Test-cvs Archives (Raw)](https://httpd.apache.org/mail/test-cvs/) 
+Archives](https://lists.apache.org/list.html?test-cvs@httpd.apache.org)
 
 # SVN access  {#SVN}
 

--- a/content/usersdelist.md
+++ b/content/usersdelist.md
@@ -49,7 +49,6 @@ Please read the following guidelines before posting to the list.
 
 -  [Jakarta/mod_jk/mod_webapp](http://jakarta.apache.org/site/mail.html) 
 
--  [mod_ssl](http://www.modssl.org/support/) 
 
 To subscribe, send an empty message to<code>
 **users-de-subscribe@httpd.apache.org** </code>. You will receive a
@@ -63,12 +62,5 @@ To unsubscribe, send a messages to<code>
 unsubscribe message from the same email address that you used to subscribe
 to the list.
 
-Archives are available at [ASF Mailing list archives](http://mail-archives.apache.org/mod_mbox/httpd-users-de/)
-or in [raw mbox format](https://httpd.apache.org/mail/users-de/). If you
-can contribute a mirror archive, please let us know.
-
-In addition, you can search the
-[English](http://groups.google.de/groups?q=comp.infosystems.www.servers) or
-[German](http://groups.google.de/groups?q=de.comm.infosystems.www.servers)
-usenet newsgroups for a much larger archive of Apache-related postings.
+Archives are available at the [ASF Mailing list archives](https://lists.apache.org/list.html?users-de@httpd.apache.org).
 

--- a/content/userslist.md
+++ b/content/userslist.md
@@ -49,20 +49,8 @@ you can contact the list administrator at
 # Archives  {#archives}
 
 Archives are available at the [Apache Mail
-Archives](http://mail-archives.apache.org/mod_mbox/httpd-users/) ,
-[MarkMail](http://httpd.markmail.org/) (great for searching),
-[MARC](http://marc.theaimsgroup.com/?l=apache-httpd-users) ,
-[CanSeek.ca](http://mla.canseek.ca/) , or in [raw mbox
-format](https://httpd.apache.org/mail/users/).
+Archives](https://lists.apache.org/list.html?users@httpd.apache.org).
 
-
-In addition, you can access this mailing list with the mail-to-news
-[gateway](nntp://news.gmane.org/) offered by
-[GMANE](http://news.gmane.org/index.php?match=gmane.comp.apache) [
-[gmane.comp.apache.user](nntp://news.gmane.org/gmane.comp.apache.user) ] or
-search the [usenet
-newsgroups](http://groups.google.com/groups?group=comp.infosystems.www.servers)
-for a much larger archive of Apache-related postings.
 # Guidelines  {#guidelines}
 
 Please read the following guidelines before posting to the list.
@@ -88,8 +76,7 @@ Please read the following guidelines before posting to the list.
 > send plain text so that everyone will be able to read your message.
 
 **Send English mails:** 
->  This list is an English-language mailing list. German-speaking users
->  may subscribe to our [German-language mailing list](usersdelist.html).
+>  This list is an English-language mailing list.
 
 **Don't ask FAQs:** 
 >  Be sure to read the [FAQ](http://wiki.apache.org/httpd/FAQ) and search


### PR DESCRIPTION
- Remove all MARC Archives links (marc.info, marc.theaimsgroup.com)
- Remove all gmane Mail-To-News gateway references
- Remove all NNTP/Usenet newsgroup sections and links
- Remove dead German users mailing list (users-de) references
- Remove defunct modules-dev (Third-Party Module Authors) list section
- Remove defunct proxy-dev (Proxy Module Rework) list section
- Remove Volume/Statistics rows from all list tables (lists.apache.org no longer serves trends.html)
- Remove MarkMail links (service is gone)
- Remove CanSeek.ca archive links
- Remove dead modssl.org/support link from usersdelist.md
- Remove dead logilune.com personal home page link (replace with plain text)
- Replace dead search.cpan.org link with metacpan.org in apreq/index.md
- Add link to Docs Project (httpd.apache.org/docs-project/) in the Documentation list description
- Replace all httpd.apache.org/mail/* URLs with lists.apache.org
- Replace all mail-archives.apache.org/mod_mbox/httpd-* URLs with lists.apache.org
- Remove duplicate "raw mbox" archive links that now point to the same lists.apache.org destination
- Replace MarkMail archive link in support.md with ASF list archives